### PR TITLE
Add dark-launch UI components

### DIFF
--- a/dev/opengb/devcards_runner.cljs
+++ b/dev/opengb/devcards_runner.cljs
@@ -1,7 +1,8 @@
 (ns ^:figwheel-hooks opengb.devcards-runner
   (:require
    [devcards.core :refer [defcard defcard-rg]]
-   [opengb.spork.leaflet-cards] ;; require for effect
+   [opengb.spork.dark-launch-cards]
+   [opengb.spork.leaflet-cards]
    [reagent.core :as r]))
 
 (defcard example

--- a/dev/opengb/devcards_runner.cljs
+++ b/dev/opengb/devcards_runner.cljs
@@ -23,5 +23,4 @@
 
 (defn ^:export init
   []
-  (stylefy/init)
   (mount))

--- a/dev/opengb/spork/dark_launch_cards.cljs
+++ b/dev/opengb/spork/dark_launch_cards.cljs
@@ -3,7 +3,7 @@
    [devcards.core :refer [defcard-rg]]
    [opengb.spork :as spork]
    [opengb.spork.dark-launch :as dark-launch]
-   [re-frame.core :as re-frame :refer [dispatch subscribe]]
+   [re-frame.core :as re-frame :refer [dispatch]]
    [reagent.core :as reagent]))
 
 (defn- register-demo-features

--- a/dev/opengb/spork/dark_launch_cards.cljs
+++ b/dev/opengb/spork/dark_launch_cards.cljs
@@ -1,0 +1,26 @@
+(ns opengb.spork.dark-launch-cards
+  (:require
+   [devcards.core :refer [defcard-rg]]
+   [opengb.spork :as spork]
+   [opengb.spork.dark-launch :as dark-launch]
+   [re-frame.core :as re-frame :refer [dispatch subscribe]]
+   [reagent.core :as reagent]))
+
+(defn- register-demo-features
+  []
+  (let [features #{:johndoe/shiny-new-feature
+                   :janedeer/improved-widgets}]
+    (doseq [feature features]
+      (dispatch [::dark-launch/register feature]))))
+
+(defcard-rg ReFrameConfigFeaturesPanel
+  (fn [*registered?]
+    (when-not *registered?
+      (spork/register-re-frame-handlers [:dark-launch])
+      (register-demo-features)
+      (reset! *registered? true))
+    [:div
+     [:button {:on-click #(dispatch [::dark-launch/show-panel])}
+      "Show features panel"]
+     [dark-launch/Panel]])
+  (reagent/atom false))

--- a/src/opengb/spork.cljs
+++ b/src/opengb/spork.cljs
@@ -1,6 +1,7 @@
 (ns opengb.spork
   "Reagent/Re-Frame view component library."
   (:require
+   [opengb.spork.dark-launch       :as dark-launch]
    [opengb.spork.design-note       :as design-note]
    [opengb.spork.error-boundary    :as error-boundary]
    [opengb.spork.keyboard-listener :as kb]
@@ -19,6 +20,8 @@
 (def DesignNote         design-note/DesignNote)
 (def DataViewer         design-note/DataViewer)
 (def ErrorBoundary      error-boundary/ErrorBoundary)
+(def FeaturePanel       dark-launch/Panel)
+(def IfFeature          dark-launch/If)
 (def KeyboardListener   kb/KeyboardListener)
 (def Markdown->Hiccup   markdown/Markdown->Hiccup)
 (def Quantity           qty/Quantity)
@@ -26,11 +29,13 @@
 (def StretchHeightWidth virtualized/AutoSizer2)
 (def StretchWidth       virtualized/AutoWidther)
 (def VegaRenderer       vega2/VegaRenderer)
+(def WhenFeature        dark-launch/When)
 
 ;; * re-frame handler registration
 
 (def ^:private get-rf-initializer
-  {:design-notes design-note/register-re-frame-handlers
+  {:dark-launch  dark-launch/register-re-frame-handlers
+   :design-notes design-note/register-re-frame-handlers
    :leaflet      leaflet/register-re-frame-handlers})
 
 (defn register-re-frame-handlers

--- a/src/opengb/spork/containers.cljs
+++ b/src/opengb/spork/containers.cljs
@@ -1,0 +1,37 @@
+(ns opengb.spork.containers)
+
+(defn Modal
+  "Displays a modal that is horizontally and vertically centered on the screen.
+  Behind the modal is a transparent backdrop that prevents the user
+  from interacting with components outside the modal.
+
+  Inspired by re-com's modal-panel (https://github.com/day8/re-com/blob/master/src/re_com/modal_panel.cljs)"
+  [{:keys [backdrop-on-click show? wrap-nicely?]} & children]
+  (when show?
+    [:div
+     {:class "spork-modal"
+      :style {:position "fixed"
+              :left     0
+              :top      0
+              :width    "100%"
+              :height   "100%"
+              :z-index  1000}}
+     [:div {:class    "spork-modal-backdrop"
+            :style    {:position         "fixed"
+                       :width            "100%"
+                       :height           "100%"
+                       :background-color "black"
+                       :opacity          0.6
+                       :z-index          1}
+            :on-click backdrop-on-click}]
+     [:div {:class "spork-modal-children"
+            :style (merge {:position "relative"
+                           :z-index  2
+                           :margin   "10vh auto"
+                           :width    "80vw"
+                           :height   "80vh"}
+                          (when wrap-nicely?
+                            {:background-color "white"
+                             :padding          "16px"
+                             :border-radius    "6px"}))}
+      children]]))

--- a/src/opengb/spork/dark_launch.cljs
+++ b/src/opengb/spork/dark_launch.cljs
@@ -104,7 +104,8 @@
                      :font-weight   "bold"
                      :border-bottom "1px solid #dedede"}}
          "Dark Launch"]
-        [:div {:class "dark-launch-panel-features-list"}
+        [:div {:class "dark-launch-panel-features-list"
+               :style {:padding "1rem 0"}}
          (doall (for [k    @*features
                       :let [enabled? (k @*feature-states)]]
                   ^{:key k}

--- a/src/opengb/spork/dark_launch.cljs
+++ b/src/opengb/spork/dark_launch.cljs
@@ -1,0 +1,118 @@
+(ns opengb.spork.dark-launch
+  (:require
+   [opengb.spork.containers :as containers]
+   [re-frame.core :refer [dispatch subscribe reg-sub reg-event-db]]))
+
+(def ^:private *registered? (atom false))
+
+(defn register-re-frame-handlers
+  "Registers dark-launch components for use.
+
+   Enables re-frame-driven toggling of the dark-launch configuration
+   panel, as well as each feature wrapped in an `If` or `When` component.
+
+   Provides these re-frame event handlers:
+
+   `[:opengb.spork.dark-launch/show-panel]`
+   `[:opengb.spork.dark-launch/hide-panel]`
+   `[:opengb.spork.dark-launch/register]`
+   `[:opengb.spork.dark-launch/enable]`
+   `[:opengb.spork.dark-launch/disable]`
+
+   Provides these re-frame subscriptions:
+   `[:opengb.spork.dark-launch/show-panel?]`
+   `[:opengb.spork.dark-launch/features]`
+   `[:opengb.spork.dark-launch/feature-states]`
+   `[:opengb.spork.dark-launch/enabled?]`"
+  []
+  ;; subs
+  (reg-sub
+   ::show-panel?
+   (fn [db] (::show-panel db)))
+
+  (reg-sub
+   ::features
+   (fn [db _] (::features db)))
+
+  (reg-sub
+   ::feature-states
+   (fn [db _] (::feature-states db)))
+
+  (reg-sub
+   ::enabled?
+   (fn [db [_ feature-key]]
+     (get-in db [::feature-states feature-key] false)))
+
+  ;; events
+  (reg-event-db
+   ::show-panel
+   (fn [db _] (assoc db ::show-panel true)))
+
+  (reg-event-db
+   ::hide-panel
+   (fn [db _] (dissoc db ::show-panel)))
+
+  (reg-event-db
+   ::register
+   (fn [db [_ feature-key]]
+     (update db ::features (fnil conj (sorted-set)) feature-key)))
+
+  (reg-event-db
+   ::enable
+   (fn [db [_ feature-key]]
+     (assoc-in db [::feature-states feature-key] true)))
+
+  (reg-event-db
+   ::disable
+   (fn [db [_ feature-key]]
+     (assoc-in db [::feature-states feature-key] false)))
+
+  (reset! *registered? true))
+
+;; * Views
+
+(defn When
+  "Wraps one component and ties the UI to the state of the flipper."
+  [feature-key _]
+  (let [*enabled? (subscribe [::enabled? feature-key])]
+    (fn [_ when-enabled]
+      (when @*enabled? when-enabled))))
+
+(defn If
+  "Wraps two components and ties the UI to the state of the flipper."
+  [feature-key _ _]
+  (let [*enabled? (subscribe [::enabled? feature-key])]
+    (fn [_ when-enabled when-disabled]
+      (if @*enabled? when-enabled when-disabled))))
+
+(defn Panel
+  "Provides a modal for enabling/disabling known UI flippers."
+  []
+  (let [*showing?       (subscribe [::show-panel?])
+        *features       (subscribe [::features])
+        *feature-states (subscribe [::feature-states])
+        on-close        #(dispatch [::hide-panel])]
+    (fn []
+      [containers/Modal
+       {:backdrop-on-click on-close
+        :show?             @*showing?
+        :wrap-nicely?      true}
+       [:div {:class "dark-launch-panel"}
+        [:p {:class "dark-launch-panel-title"
+             :style {:font-size     "1.5rem"
+                     :line-height   "1.3rem"
+                     :font-weight   "bold"
+                     :border-bottom "1px solid #dedede"}}
+         "Dark Launch"]
+        [:div {:class "dark-launch-panel-features-list"}
+         (doall (for [k    @*features
+                      :let [enabled? (k @*feature-states)]]
+                  ^{:key k}
+                  [:div
+                   [:label
+                    [:input
+                     {:type    "checkbox"
+                      :checked enabled?
+                      :on-click
+                      #(dispatch [(if enabled? ::disable ::enable) k])}]
+                    [:span (str k)]]]))]]])))


### PR DESCRIPTION
- add function to register
  Re-Frame subscriptions and event handlers
  to control whether other components
  are shown, based on 'feature flags'.
- add Reagent components
  for showing the list of feature flags
  and for controlling visibility
  of wrapped components.
