### PR TITLE
Allow setting width and height for modal pop-up

### DIFF
--- a/src/opengb/spork/containers.cljs
+++ b/src/opengb/spork/containers.cljs
@@ -6,7 +6,10 @@
   from interacting with components outside the modal.
 
   Inspired by re-com's modal-panel (https://github.com/day8/re-com/blob/master/src/re_com/modal_panel.cljs)"
-  [{:keys [backdrop-on-click show? wrap-nicely?]} & children]
+  [{:keys [backdrop-on-click width height show? wrap-nicely?]
+    :or   {width  "80vw"
+           height "80vh"}}
+   & children]
   (when show?
     [:div
      {:class "spork-modal"
@@ -24,14 +27,18 @@
                        :opacity          0.6
                        :z-index          1}
             :on-click backdrop-on-click}]
-     [:div {:class "spork-modal-children"
-            :style (merge {:position "relative"
-                           :z-index  2
-                           :margin   "10vh auto"
-                           :width    "80vw"
-                           :height   "80vh"}
-                          (when wrap-nicely?
-                            {:background-color "white"
-                             :padding          "16px"
-                             :border-radius    "6px"}))}
-      children]]))
+     [:div {:style {:height          "100%"
+                    :width           "100%"
+                    :display         "flex"
+                    :justify-content "space-around"
+                    :align-items     "center"}}
+      [:div {:class "spork-modal-children"
+             :style (merge {:position "relative"
+                            :z-index  2
+                            :width    width
+                            :height   height}
+                           (when wrap-nicely?
+                             {:background-color "white"
+                              :padding          "16px"
+                              :border-radius    "6px"}))}
+       children]]]))


### PR DESCRIPTION
- use CSS flexbox to center the modal pop-up on the screen
- allow setting the width and height of the pop-up
