### PR TITLE
missing on-click handler error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/clojure:tools-deps-node-browsers
+      - image: cimg/clojure:1.11.1-openjdk-17.0-browsers
     working_directory: ~/repo
     environment:
       LEIN_ROOT: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .lein-failures
 .lein-plugins/
 .lein-repl-history
+.lsp
 .nrepl-port
 /checkouts/
 /classes/

--- a/src/opengb/spork/vega2.cljs
+++ b/src/opengb/spork/vega2.cljs
@@ -35,19 +35,21 @@
 
 (defn mount-component
   [a-ref this-component]
-  (let [props     (reagent/props this-component)
-        vega-spec (clj->js (or (:vega-spec props) {}))
-        on-click  (:on-click props)
-        runtime   (.parse js/vega vega-spec)
-        view      (-> (js/vega.View. runtime)
-                      (.initialize a-ref)
-                      (.addEventListener "click" #(on-click %))
-                      (.renderer "svg")
-                      (.hover))]
+  (let [props          (reagent/props this-component)
+        vega-spec      (clj->js (or (:vega-spec props) {}))
+        runtime        (.parse js/vega vega-spec)
+        view           (-> (js/vega.View. runtime)
+                           (.initialize a-ref)
+                           (.renderer "svg")
+                           (.hover))
+        on-click       (:on-click props)
+        clickable-view (if (ifn? on-click)
+                         (.addEventListener view "click" #(on-click %))
+                         view)]
     ;; uncomment to debug in signal expressions
     ;; see https://vega.github.io/vega/docs/expressions/#debug
     ; (.logLevel view js/vega.Warn)
-    (.run view)
+    (.run clickable-view)
     view))
 
 (defn VegaRenderer


### PR DESCRIPTION
VegaRenderer currently adds an on-click handler even when one is not supplied to the component. If the chart is then clicked it throws an error in the console.

This conditionally adds a handler only when one is supplied.