### PR TITLE
make `subdomains nilable` for leaflet-tile-config

### DIFF
--- a/src/opengb/spork/leaflet_specs.cljc
+++ b/src/opengb/spork/leaflet_specs.cljc
@@ -16,7 +16,7 @@
 
 (s/def ::attribution ::localizable-string)
 (s/def ::url         ::localizable-string)
-(s/def ::subdomains  ::non-empty-string)
+(s/def ::subdomains  (s/nilable ::non-empty-string))
 (s/def ::min-zoom    ::geo/zoom)
 (s/def ::max-zoom    ::geo/zoom)
 


### PR DESCRIPTION
Since `subdomains` is an optional field on `leaflet-tile-config`, it should be ok for it to be nil in addition to just missing entirely.

In `grid`, the basemap config is defined in a `.edn` file and subdomains is populated based on environment variables such that it is possible for `subdomains` to be nil; this should be an acceptable case the same as if `subdomains` were missing entirely.